### PR TITLE
fix: fixed bug that was sending users to signout if unauthorized

### DIFF
--- a/backend/app/gptcotts/auth_utils.py
+++ b/backend/app/gptcotts/auth_utils.py
@@ -42,6 +42,7 @@ def get_user_info(token: str) -> dict | None:
     response = requests.get(
         "https://www.googleapis.com/oauth2/v3/userinfo", headers=headers
     )
+    logging.debug(response)
     if response.status_code == 200:
         return response.json()
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,3 @@ boto3==1.34.141
 anthropic==0.30.1
 python-multipart==0.0.9
 pydantic[email]==2.8.2
-google-auth==2.38.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ boto3==1.34.141
 anthropic==0.30.1
 python-multipart==0.0.9
 pydantic[email]==2.8.2
+google-auth==2.38.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,5 +8,5 @@ cachetools==5.5.0
 cohere==5.5.8
 boto3==1.34.141
 anthropic==0.30.1
-python-multipart==0.0.9
+python-multipart==0.0.18
 pydantic[email]==2.8.2

--- a/frontend/app/api/auth/[...nextauth]/authOptions.ts
+++ b/frontend/app/api/auth/[...nextauth]/authOptions.ts
@@ -1,146 +1,146 @@
 import Google from "next-auth/providers/google";
 import { TokenSet } from "next-auth";
 
-function validateProcessEnv(): {clientId: string, clientSecret: string} {
-    let clientId: string;
-    if (process.env.GOOGLE_CLIENT_ID) {
-        clientId = process.env.GOOGLE_CLIENT_ID;
-    } else {
-        throw new Error('GOOGLE_CLIENT_ID is not defined');
-    }
+function validateProcessEnv(): { clientId: string, clientSecret: string } {
+  let clientId: string;
+  if (process.env.GOOGLE_CLIENT_ID) {
+    clientId = process.env.GOOGLE_CLIENT_ID;
+  } else {
+    throw new Error('GOOGLE_CLIENT_ID is not defined');
+  }
 
-    let clientSecret: string;
-    if (process.env.GOOGLE_CLIENT_SECRET) {
-        clientSecret = process.env.GOOGLE_CLIENT_SECRET;
-    } else {
-        throw new Error('GOOGLE_CLIENT_SECRET is not defined');
-    }
+  let clientSecret: string;
+  if (process.env.GOOGLE_CLIENT_SECRET) {
+    clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  } else {
+    throw new Error('GOOGLE_CLIENT_SECRET is not defined');
+  }
 
-    return {clientId, clientSecret}
+  return { clientId, clientSecret }
 }
 
 async function refreshAccessToken(token: TokenSet): Promise<TokenSet> {
-    
-    if (!token.refresh_token) {
-        console.log("No refresh token")
-        return {
-            ...token,
-            error: "NoRefreshToken",
-        }
+
+  if (!token.refresh_token) {
+    return {
+      ...token,
+      error: "NoRefreshToken",
     }
+  }
 
-    try {
-    
-        const {clientId, clientSecret} = validateProcessEnv()
-         
-        const response = await fetch("https://oauth2.googleapis.com/token", {
-            method: "POST",
-            body: new URLSearchParams({
-                client_id: clientId,
-                client_secret: clientSecret,
-                grant_type: "refresh_token",
-                refresh_token: token.refresh_token,
-            }),
-        })
+  try {
 
-        const tokensOrError = await response.json()
-        if (!response.ok) throw tokensOrError
+    const { clientId, clientSecret } = validateProcessEnv()
 
-        token.access_token = tokensOrError.access_token
-        token.expires_at = Math.floor(
-            Date.now() + tokensOrError.expires_in
-        )
+    const response = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+      }),
+    })
 
-          if (tokensOrError.refresh_token) {
-              token.refresh_token = tokensOrError.refresh_token
-          }
-            console.log("Token refreshed")
-          return token
-    } catch (error) {
-          console.log(error)
-          return {
-            ...token,
-            error: "RefreshAccessTokenError",
-          }
+    const tokensOrError = await response.json()
+    if (!response.ok) throw tokensOrError
+
+    token.access_token = tokensOrError.access_token
+    token.expires_at = Math.floor(
+      Date.now() + tokensOrError.expires_in
+    )
+
+    if (tokensOrError.refresh_token) {
+      token.refresh_token = tokensOrError.refresh_token
     }
+    return token
+  } catch (error) {
+    return {
+      ...token,
+      error: "RefreshAccessTokenError",
+    }
+  }
 }
 
-const {clientId, clientSecret} = validateProcessEnv()
+const { clientId, clientSecret } = validateProcessEnv()
 
 
 export const authOptions = {
-    providers: [
-        Google({
-            clientId: clientId,
-            clientSecret: clientSecret,
-            authorization: {
-                params: {
-                    prompt: "consent",
-                    access_type: "offline",
-                    response_type: "code",
-                }
-            }
-        }),
-      ],
-      callbacks: {
-        async jwt(
-            // @ts-expect-error, this should be the any type. https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/types.ts
-            { token, user, account }
-        ) {
+  providers: [
+    Google({
+      clientId: clientId,
+      clientSecret: clientSecret,
+      authorization: {
+        params: {
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code",
+        }
+      }
+    }),
+  ],
+  callbacks: {
+    async jwt(
+      // @ts-expect-error, this should be the any type. https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/types.ts
+      { token, user, account }
+    ) {
 
-            if (!token) {
-                console.log("No token")
-                return {
-                    access_token: "",
-                    expires_at: 0,
-                    error: "NoToken",
-                    user: user
-                }
-            }
+      if (!token) {
+        return {
+          id_token: "",
+          access_token: "",
+          expires_at: 0,
+          error: "NoToken",
+          user: user
+        }
+      }
 
-            if (account && user) {
-                return {
-                    access_token: account.access_token,
-                    expires_at: account.expires_at,
-                    refresh_token: account.refresh_token,
-                    error: "NoError",
-                    user: user,
-                }
-            }
-            if (Date.now() < (token.expires_at * 1000)) {
-                token.error = "NoError"
-                return {
-                    ...token,
-                }
-            }
+      if (account && user) {
+        return {
+          id_token: account.id_token,
+          access_token: account.access_token,
+          expires_at: account.expires_at,
+          refresh_token: account.refresh_token,
+          error: "NoError",
+          user: user,
+        }
+      }
+      if (Date.now() < (token.expires_at * 1000)) {
+        token.error = "NoError"
+        return {
+          ...token,
+        }
+      }
 
-            const refreshedToken = await refreshAccessToken(token)
-            return {
-                access_token: refreshedToken.access_token,
-                expires_at: refreshedToken.expires_at,
-                refresh_token: refreshedToken.refresh_token,
-                error: refreshedToken.error,
-                user: refreshedToken.user
-            }
+      const refreshedToken = await refreshAccessToken(token)
+      return {
+        id_token: refreshedToken.id_token,
+        access_token: refreshedToken.access_token,
+        expires_at: refreshedToken.expires_at,
+        refresh_token: refreshedToken.refresh_token,
+        error: refreshedToken.error,
+        user: refreshedToken.user
+      }
 
 
-        },
-        // @ts-expect-error, this should be the any type. https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/types.ts
-        async session({ session, token }) {
-            
-            if (token) {
-                session.user.name = token.user.name
-                session.user.email = token.user.email
-                session.access_token = token.access_token
-                session.error = token.error
-                session.expires = token.expires_at
-            }
-            return session
-        },
     },
-    pages: {
-        signIn: '/auth/signin',
-        signOut: '/auth/signout',
-    }
+    // @ts-expect-error, this should be the any type. https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/types.ts
+    async session({ session, token }) {
+
+      if (token) {
+        session.user.name = token.user.name
+        session.user.email = token.user.email
+        session.access_token = token.access_token
+        session.id_token = token.id_token
+        session.error = token.error
+        session.expires = token.expires_at
+      }
+      return session
+    },
+  },
+  pages: {
+    signIn: '/auth/signin',
+    signOut: '/auth/signout',
+  }
 }
 

--- a/frontend/app/api/auth/[...nextauth]/authOptions.ts
+++ b/frontend/app/api/auth/[...nextauth]/authOptions.ts
@@ -54,7 +54,7 @@ async function refreshAccessToken(token: TokenSet): Promise<TokenSet> {
       token.refresh_token = tokensOrError.refresh_token
     }
     return token
-  } catch (error) {
+  } catch {
     return {
       ...token,
       error: "RefreshAccessTokenError",

--- a/frontend/app/notes/page.tsx
+++ b/frontend/app/notes/page.tsx
@@ -39,7 +39,7 @@ async function AuthenticatedNotesContent() {
     return response
   }
 
-  let response = await makeRequest(session.access_token)
+  const response = await makeRequest(session.access_token)
 
   if (response.status !== 200) {
     return <p> Unable to load notes, try again later </p>

--- a/frontend/app/notes/page.tsx
+++ b/frontend/app/notes/page.tsx
@@ -24,20 +24,27 @@ async function AuthenticatedNotesContent() {
     return redirect('/api/auth/signout/google')
   }
 
-  const request_options = {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'accept': 'application/json',
-      'Authorization': `Bearer ${session.access_token}`
+
+  const makeRequest = async (token: string) => {
+    const request_options = {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'accept': 'application/json',
+        'Authorization': `Bearer ${token}`
+      }
     }
+
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/notes/get`, request_options)
+    return response
   }
 
-  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/notes/get`, request_options)
+  let response = await makeRequest(session.access_token)
 
   if (response.status !== 200) {
-    return redirect('/api/auth/signout/google')
+    return <p> Unable to load notes, try again later </p>
   }
+
 
   const data = await response.json()
   const note: Note = data.note

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -66,7 +66,7 @@ export default function Home() {
     }
     getValidity()
 
-  }, [session])
+  }, [session, update])
 
   if (status === "loading") {
     return (

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -26,7 +26,6 @@ export default async function Profile() {
     return redirect("/api/auth/signout/google")
   }
 
-  console.log(username, email)
 
   const requestOptions = {
     method: 'GET',

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -368,7 +368,7 @@ export function Chat({ valid, initChats }: { valid: boolean, initChats: ChatMess
     }
 
     try {
-      let response = await sendMessage(request, url);
+      const response = await sendMessage(request, url);
       let value = ""
       const context = response.headers.get('x-relevant-context');
       let parsedContext: Array<ContextItem> = [];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.3",
         "lodash": "^4.17.21",
-        "next": "14.2.14",
+        "next": "14.2.21",
         "next-auth": "^4.24.8",
         "react": "^18",
         "react-dom": "^18",

--- a/frontend/types/next-auth.d.ts
+++ b/frontend/types/next-auth.d.ts
@@ -1,13 +1,14 @@
 import NextAuth from 'next-auth'
 
 declare module 'next-auth' {
-    interface Session {
-        access_token: string
-        expires: number
-        user: {
-            name: string
-            email: string
-        }
-        error: string
+  interface Session {
+    id_token: string
+    access_token: string
+    expires: number
+    user: {
+      name: string
+      email: string
     }
+    error: string
+  }
 }


### PR DESCRIPTION
previously, if any backend request returned a 401 the front-end would freak and go to the signout page. I've stopped this, and the token is refreshed, before trying again and then only throwing an error if that second time fails.